### PR TITLE
Simplify config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,10 +13,9 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     cdndeps: {
-      main: {
-        files: {
-          "deps": ["example_deps.json"]
-        }
+      options: {
+        src: "example_deps.json",
+        dest: "deps"
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -24,26 +24,15 @@ grunt.loadNpmTasks('grunt-cdndeps');
 ### Overview
 In your project's Gruntfile, add a section named `cdndeps` to the data object passed into `grunt.initConfig()`.
 
-```js
-grunt.initConfig({
-  cdndeps: {
-    your_target: {
-      // Target-specific file lists and/or options go here.
-    },
-  },
-})
-```
-
-### Usage Examples
-
 In this example, `grunt-cdndeps` will read the contents of `package.json` and try to find a `cdnDeps` key whose value is a list of CDN urls, or an object whose values are lists of CDN urls. It will then download all of those files into `tmp/cdns`.
 
 ```js
 grunt.initConfig({
   cdndeps: {
-    files: {
-      "tmp/cdns": ["package.json"],
-    },
+    options: {
+      src: "package.json",
+      dest: "tmp/cdns"
+    }
   },
 })
 
@@ -120,9 +109,9 @@ require("grunt-cdndeps")({
 })
 ```
 
-- `production`, Boolean -- whether the resulting list of paths will be used in a production environment.
-- `src`, String -- the source file used by `grunt-cdndeps`
-- `dest`, String -- the target folder used by `grunt-cdndeps`
+- `production`, Boolean, Default: `false` -- whether the resulting list of paths will be used in a production environment.
+- `src`, String, Default: `grunt.config("cdndeps.options.src")` -- the source file used by `grunt-cdndeps`
+- `dest`, String, Default: `grunt.config("cdndeps.options.dest")` -- the target folder used by `grunt-cdndeps`
 
 If `production` is set to `true`, a list of the actual URLs from the JSON will be returned, but with `.min.js` appended. If `false`, a list of filepaths to the libraries in the `cdn_folder` will be returned.
 
@@ -139,7 +128,7 @@ For cases where simply appending ".min.js" to a given URL will produce an invali
 ]
 ```
 
-In the above case, calling `cdn_paths` with `production = true` will give us `//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.2/raphael-min.js`. With `production = false`, we will instead get `cdns/DmitryBaranovskiy/raphael/v2.1.2/raphael.js`.
+In the above case, calling `cdn_paths` with `production: true` will give us `//cdnjs.cloudflare.com/ajax/libs/raphael/2.1.2/raphael-min.js`. With `production: false`, we will instead get `cdns/DmitryBaranovskiy/raphael/v2.1.2/raphael.js`.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/lib/cdn_paths.js
+++ b/lib/cdn_paths.js
@@ -39,9 +39,10 @@ var grunt = require("grunt");
 var rel_path = require("./rel_path");
 
 module.exports = function (config) {
-  var src_file   = config.src,
-      dest_dir   = config.dest,
-      production = config.production;
+
+  var src_file   = config.src || grunt.config("cdndeps.options.src"),
+      dest_dir   = config.dest || grunt.config("cdndeps.options.dest"),
+      production = config.production || false;
 
   var deps_object = grunt.file.readJSON(src_file).cdnDeps;
 

--- a/tasks/cdndeps.js
+++ b/tasks/cdndeps.js
@@ -18,47 +18,50 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-contrib-clean");
   grunt.loadNpmTasks("grunt-curl");
 
-  grunt.registerMultiTask("cdndeps",
-                          "Local CDN dependency manager.",
-                          function() {
+  grunt.registerTask("cdndeps",
+                      "Local CDN dependency manager.",
+                      function() {
 
-    this.files.forEach(function(mapping) {
+    var mapping = this.options();
 
-      validate_mapping(mapping);
+    validate_mapping(mapping);
 
-      var deps     = grunt.file.readJSON(mapping.src).cdnDeps,
-          dep_urls = extract_paths(deps);
+    var deps     = grunt.file.readJSON(mapping.src).cdnDeps,
+        dep_urls = extract_paths(deps);
 
-      // Define a mapping between required cdn url
-      // and the file path it is supposed to populate
-      var required_map = get_required_map(mapping.dest, dep_urls);
+    // Define a mapping between required cdn url
+    // and the file path it is supposed to populate
+    var required_map = get_required_map(mapping.dest, dep_urls);
 
-      var existing_files   = get_existing(mapping.dest),
-          required_files   = Object.keys(required_map),
-          missing_files    = _.difference(required_files, existing_files),
-          unrequired_files = _.difference(existing_files, required_files);
+    var existing_files   = get_existing(mapping.dest),
+        required_files   = Object.keys(required_map),
+        missing_files    = _.difference(required_files, existing_files),
+        unrequired_files = _.difference(existing_files, required_files);
 
-      if (missing_files.length) {
-        download(_.pick(required_map, missing_files));
-      }
+    if (missing_files.length) {
+      download(_.pick(required_map, missing_files));
+    }
 
-      if (unrequired_files.length) {
-        remove(unrequired_files);
-      }
+    if (unrequired_files.length) {
+      remove(unrequired_files);
+    }
 
-      // Finally clean any directories that might have become empty
-      configure_clean(mapping.dest);
-      grunt.task.run("clean:cdndeps");
-    });
+    // Finally clean any directories that might have become empty
+    configure_clean(mapping.dest);
+    grunt.task.run("clean:cdndeps");
   });
 
   function validate_mapping (mapping) {
-    if (grunt.file.isFile(mapping.dest)) {
-      grunt.warn("Destination for CDN dependencies needs to be a directory");
+    if (_.isArray(mapping.src)) {
+      grunt.warn("Please specify only one source file for cdndeps as a String, that lists all required libraries.");
     }
 
-    if (mapping.src.length > 1) {
-      grunt.warn("Please specify only one source file for cdndeps that lists all required libraries");
+    if (_.isArray(mapping.dest)) {
+      grunt.warn("Please specify the destination directory as a String.");
+    }
+
+    if (grunt.file.isFile(mapping.dest)) {
+      grunt.warn("Destination for CDN dependencies needs to be a directory.");
     }
   }
 


### PR DESCRIPTION
- Because the task only ever tolerates a single input file and a single output directory, no need to use a multitask with complex file patterns, just pass the `src` and `dest` as options.
- With pre-determined `src` and `dest` properties in the configuration (instead of different file formats), we can have `cdndeps.options.src` and `cdndeps.options.dest` as default config variables for `cdn_paths`.
