### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
     "name": "Cambridge Healthcare",
     "email": "hello@cambridgehealthcare.com"
   },
-  "contributors": [{
-    "name": "Elise Hein",
-    "email": "elise@howareyou.com"
-  }, {
-    "name": "Szymon Witamborski",
-    "email": "szymon@howareyou.com"
-  }],
+  "contributors": [
+    {
+      "name": "Elise Hein",
+      "email": "elise@howareyou.com"
+    },
+    {
+      "name": "Szymon Witamborski",
+      "email": "szymon@howareyou.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/cambridge-healthcare/grunt-cdndeps"
@@ -41,7 +44,7 @@
     "underscore": "1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
